### PR TITLE
Fix destroy workflow to handle client VM destruction via SSH

### DIFF
--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -58,49 +58,98 @@ jobs:
             echo "tag=linux-amd64-latest-test" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Terraform Init Client VMs
-        working-directory: packages/allocator/src/lablink_allocator/terraform
-        run: |
-          # Extract bucket name from config.yaml
-          BUCKET_NAME=$(grep "^bucket_name:" ../conf/config.yaml | awk '{print $2}' | tr -d '"')
-          terraform init \
-            -backend-config=backend-client-${{ github.event.inputs.environment }}.hcl \
-            -backend-config="bucket=$BUCKET_NAME"
-
-      - name: Extract Variable File
-        working-directory: packages/allocator/src/lablink_allocator/terraform
-        run: |
-          # Extract bucket name from config.yaml
-          BUCKET_NAME=$(grep "^bucket_name:" ../conf/config.yaml | awk '{print $2}' | tr -d '"')
-          # Try to download tfvars, but don't fail if it doesn't exist (no VMs were created)
-          if aws s3 cp s3://${BUCKET_NAME}/${{ github.event.inputs.environment }}/client/terraform.runtime.tfvars variables.tfvars 2>/dev/null; then
-            echo "Found existing client VM state"
-            echo "has_client_vms=true" >> "$GITHUB_ENV"
-          else
-            echo "No client VM state found - skipping client VM destruction"
-            echo "has_client_vms=false" >> "$GITHUB_ENV"
-          fi
-
-      - name: Terraform Destroy Client VMs
-        if: env.has_client_vms == 'true'
-        continue-on-error: true
-        working-directory: packages/allocator/src/lablink_allocator/terraform
-        run: |
-          terraform destroy -auto-approve -var-file=variables.tfvars
-
+      # Initialize terraform to access outputs (IP and SSH key)
       - name: Terraform Init Infrastructure
         working-directory: lablink-infrastructure
         run: |
-          # Extract bucket name from config.yaml for S3 backend
           BUCKET_NAME=$(grep "^bucket_name:" config/config.yaml | awk '{print $2}' | tr -d '"')
           terraform init \
             -backend-config=backend-${{ github.event.inputs.environment }}.hcl \
             -backend-config="bucket=$BUCKET_NAME"
 
+      - name: Get Allocator Connection Info
+        id: allocator_info
+        working-directory: lablink-infrastructure
+        run: |
+          # Get allocator public IP
+          ALLOCATOR_IP=$(terraform output -raw ec2_public_ip)
+          echo "allocator_ip=$ALLOCATOR_IP" >> "$GITHUB_OUTPUT"
+          echo "Allocator IP: $ALLOCATOR_IP"
+
+          # Get SSH private key and save to file
+          terraform output -raw private_key_pem > /tmp/lablink-key.pem
+          chmod 600 /tmp/lablink-key.pem
+          echo "SSH key saved"
+
+      - name: Destroy Client VMs via Allocator
+        continue-on-error: true
+        run: |
+          echo "Attempting to destroy client VMs via allocator at ${{ steps.allocator_info.outputs.allocator_ip }}"
+
+          # Wait for SSH to be ready (allocator might still be booting)
+          echo "Waiting for SSH connection..."
+          for i in {1..30}; do
+            if ssh -i /tmp/lablink-key.pem -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+                ubuntu@${{ steps.allocator_info.outputs.allocator_ip }} "echo 'SSH ready'" 2>/dev/null; then
+              echo "✓ SSH connection established"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "⚠ SSH connection timeout - allocator may already be destroyed"
+              exit 0
+            fi
+            echo "  Attempt $i/30..."
+            sleep 10
+          done
+
+          # Destroy client VMs by running terraform inside the allocator container
+          echo "Connecting to allocator to destroy client VMs..."
+          ssh -i /tmp/lablink-key.pem -o StrictHostKeyChecking=no \
+              ubuntu@${{ steps.allocator_info.outputs.allocator_ip }} << 'ENDSSH'
+            # Get the allocator container ID
+            CONTAINER_ID=$(docker ps --filter "ancestor=ghcr.io/talmolab/lablink-allocator" --format "{{.ID}}" | head -n 1)
+
+            if [ -z "$CONTAINER_ID" ]; then
+              echo "⚠ No allocator container found - client VMs may already be destroyed"
+              exit 0
+            fi
+
+            echo "✓ Found allocator container: $CONTAINER_ID"
+
+            # Run terraform destroy inside the container
+            docker exec $CONTAINER_ID bash -c '
+              cd /app/lablink_allocator/terraform
+
+              # Check if terraform state exists
+              if ! terraform show 2>/dev/null | grep -q "resource"; then
+                echo "✓ No client VMs in terraform state"
+                exit 0
+              fi
+
+              # Destroy all client VMs
+              echo "Destroying client VMs..."
+              if terraform destroy -auto-approve; then
+                echo "✓ Client VMs destroyed successfully"
+              else
+                echo "⚠ Client VM destruction failed or no VMs to destroy (non-fatal)"
+              fi
+            '
+          ENDSSH
+
+          echo "✓ Client VM destruction attempt completed"
+
+      - name: Clean Up SSH Key
+        if: always()
+        run: |
+          rm -f /tmp/lablink-key.pem
+          echo "SSH key cleaned up"
+
       - name: Terraform Destroy Infrastructure
         working-directory: lablink-infrastructure
         run: |
+          echo "Destroying allocator infrastructure..."
           terraform destroy -auto-approve \
             -var="resource_suffix=${{ github.event.inputs.environment }}" \
             -var="allocator_image_tag=${{ steps.resolve_image_tag.outputs.tag }}" \
             -var-file="terraform.tfvars"
+          echo "✓ Infrastructure destroyed"

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -108,7 +108,7 @@ jobs:
           ssh -i /tmp/lablink-key.pem -o StrictHostKeyChecking=no \
               ubuntu@${{ steps.allocator_info.outputs.allocator_ip }} << 'ENDSSH'
             # Get the allocator container ID
-            CONTAINER_ID=$(docker ps --filter "ancestor=ghcr.io/talmolab/lablink-allocator" --format "{{.ID}}" | head -n 1)
+            CONTAINER_ID=$(sudo docker ps --filter "ancestor=ghcr.io/talmolab/lablink-allocator" --format "{{.ID}}" | head -n 1)
 
             if [ -z "$CONTAINER_ID" ]; then
               echo "⚠ No allocator container found - client VMs may already be destroyed"
@@ -118,7 +118,7 @@ jobs:
             echo "✓ Found allocator container: $CONTAINER_ID"
 
             # Run terraform destroy inside the container
-            docker exec $CONTAINER_ID bash -c '
+            sudo docker exec $CONTAINER_ID bash -c '
               cd /app/lablink_allocator/terraform
 
               # Check if terraform state exists

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -44,6 +44,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.6.6
+          terraform_wrapper: false
 
       - name: Validate and determine image tag
         id: resolve_image_tag


### PR DESCRIPTION
## Summary

Fixes the destroy workflow which was failing because it referenced a non-existent `packages/allocator/` directory structure. The workflow now properly destroys both client VMs and allocator infrastructure.

Fixes #2

## Problem

The destroy workflow was failing with:
```
An error occurred trying to start process '/usr/bin/bash' with working directory 
'/home/runner/work/sleap-lablink/sleap-lablink/packages/allocator/src/lablink_allocator/terraform'. 
No such file or directory
```

This repository is a template repository with infrastructure at `lablink-infrastructure/`, NOT in a `packages/` directory structure that exists in the main LabLink monorepo.

## Solution

### Removed (Lines 61-89)
- ❌ Terraform Init Client VMs (referenced non-existent directory)
- ❌ Extract Variable File (referenced non-existent directory)
- ❌ Terraform Destroy Client VMs (referenced non-existent directory)

### Added
- ✅ **Get Allocator Connection Info**: Extract IP and SSH key from terraform outputs
- ✅ **Destroy Client VMs via Allocator**: SSH into allocator, run terraform destroy inside Docker container
- ✅ **Clean Up SSH Key**: Always remove temporary SSH key file

### How It Works

1. **Terraform Init** → Initialize to read allocator state
2. **Get IP & SSH Key** → Extract from terraform outputs
3. **SSH to Allocator** → Connect to EC2 instance (retry 30 times over 5 minutes)
4. **Find Container** → Get allocator Docker container ID
5. **Destroy Client VMs** → Run terraform destroy inside container
6. **Clean Up** → Remove SSH key
7. **Destroy Allocator** → Destroy EC2, security groups, SSH key, etc.

## Error Handling

- **Client VM destruction**: Uses `continue-on-error: true` - won't fail workflow if no VMs exist
- **SSH connection**: Retries 30 times (5 minutes), gracefully exits if allocator already destroyed
- **Missing container**: Detects and handles gracefully
- **No terraform state**: Detects and exits gracefully
- **SSH key cleanup**: Always runs with `if: always()`

## Changes

```diff
 .github/workflows/terraform-destroy.yml | 105 +++++++++++++++++++++++---------
 1 file changed, 77 insertions(+), 28 deletions(-)
```

**Key Changes:**
- Working directory: `lablink-infrastructure/` (matches deploy workflow ✅)
- Config path: `config/config.yaml` (matches deploy workflow ✅)
- Client VM destruction: Via SSH to allocator container (new approach ✅)

## Testing Plan

### Test Case 1: With Client VMs
1. Deploy to test environment
2. Create 1-2 client VMs via web interface
3. Run destroy workflow
4. **Expected**: Client VMs destroyed, then allocator destroyed

### Test Case 2: Without Client VMs
1. Deploy to test environment
2. Don't create any client VMs
3. Run destroy workflow
4. **Expected**: Workflow completes with "No client VMs in terraform state" message

### Test Case 3: Allocator Already Destroyed
1. Manually destroy allocator
2. Run destroy workflow
3. **Expected**: SSH times out gracefully, workflow exits cleanly

## Workflow Steps

```yaml
1. Validate image tag
2. Terraform Init Infrastructure
3. Get Allocator Connection Info (IP + SSH key)
4. Destroy Client VMs via Allocator (continue-on-error)
5. Clean Up SSH Key (always)
6. Terraform Destroy Infrastructure
```

## Benefits

✅ **Complete automation** - Destroys both client VMs and allocator in one workflow
✅ **Safe error handling** - Won't fail if client VMs don't exist
✅ **Uses existing credentials** - Allocator's IAM instance profile has AWS permissions
✅ **No duplicate state** - Uses terraform state inside the container
✅ **Matches deploy workflow** - Same paths and config structure

## Breaking Changes

None - this is a fix for a broken workflow that never worked in template repositories.

## Related Issues

- Fixes #2 (destroy workflow fails on template repos)
- Related to failing E2E test workflow (separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)